### PR TITLE
Eager load includes for related resources (#1163)

### DIFF
--- a/jsonapi-resources.gemspec
+++ b/jsonapi-resources.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'concurrent-ruby-ext'
+  spec.add_development_dependency 'bullet'
   spec.add_dependency 'activerecord', '>= 4.1'
   spec.add_dependency 'railties', '>= 4.1'
   spec.add_dependency 'concurrent-ruby'

--- a/lib/jsonapi/relationship_builder.rb
+++ b/lib/jsonapi/relationship_builder.rb
@@ -60,6 +60,8 @@ module JSONAPI
 
         resource_klass = relationship.resource_klass
 
+        records = resource_klass.apply_includes(records, options)
+
         filters = options.fetch(:filters, {})
         unless filters.nil? || filters.empty?
           records = resource_klass.apply_filters(records, filters, options)

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -3134,7 +3134,7 @@ class Api::V2::BooksControllerTest < ActionController::TestCase
     end
     assert_response :success
     assert_equal 12, json_response['data'].size
-    assert_equal 132, json_response['included'].size
+    assert_equal 135, json_response['included'].size
     assert_equal 'Book 0', json_response['data'][0]['attributes']['title']
     assert_equal 901, json_response['meta']['record-count']
   ensure

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -483,7 +483,7 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration.top_level_meta_include_record_count = true
     assert_cacheable_get :show, params: { id: Post.first.id }
     assert_response :success
-    assert_equal json_response['meta'], nil
+    assert_nil json_response['meta']
   ensure
     JSONAPI.configuration.top_level_meta_include_record_count = false
   end
@@ -492,7 +492,7 @@ class PostsControllerTest < ActionController::TestCase
     JSONAPI.configuration.top_level_meta_include_page_count = true
     assert_cacheable_get :show, params: { id: Post.first.id }
     assert_response :success
-    assert_equal json_response['meta'], nil
+    assert_nil json_response['meta']
   ensure
     JSONAPI.configuration.top_level_meta_include_page_count = false
   end
@@ -596,7 +596,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /id is not allowed/, response.body
-    assert_equal nil,response.location
+    assert_nil response.location
   end
 
   def test_create_link_to_missing_object
@@ -618,7 +618,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
     # TODO: check if this validation is working
     assert_match /author - can't be blank/, response.body
-    assert_equal nil, response.location
+    assert_nil response.location
   end
 
   def test_create_extra_param
@@ -640,7 +640,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /asdfg is not allowed/, response.body
-    assert_equal nil,response.location
+    assert_nil response.location
   end
 
   def test_create_extra_param_allow_extra_params
@@ -707,7 +707,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_equal "/data/attributes/title", json_response['errors'][1]['source']['pointer']
     assert_equal "is too long (maximum is 35 characters)", json_response['errors'][1]['title']
     assert_equal "title - is too long (maximum is 35 characters)", json_response['errors'][1]['detail']
-    assert_equal nil, response.location
+    assert_nil response.location
   end
 
   def test_create_multiple
@@ -760,7 +760,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /The required parameter, data, is missing./, json_response['errors'][0]['detail']
-    assert_equal nil, response.location
+    assert_nil response.location
   end
 
   def test_create_simple_wrong_type
@@ -781,7 +781,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /posts_spelled_wrong is not a valid resource./, json_response['errors'][0]['detail']
-    assert_equal nil, response.location
+    assert_nil response.location
   end
 
   def test_create_simple_missing_type
@@ -801,7 +801,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /The required parameter, type, is missing./, json_response['errors'][0]['detail']
-    assert_equal nil, response.location
+    assert_nil response.location
   end
 
   def test_create_simple_unpermitted_attributes
@@ -822,7 +822,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :bad_request
     assert_match /subject/, json_response['errors'][0]['detail']
-    assert_equal nil, response.location
+    assert_nil response.location
   end
 
   def test_create_simple_unpermitted_attributes_allow_extra_params
@@ -1086,7 +1086,7 @@ class PostsControllerTest < ActionController::TestCase
     assert_response :success
     assert json_response['data'].is_a?(Hash)
     assert_equal '3', json_response['data']['relationships']['author']['data']['id']
-    assert_equal nil, json_response['data']['relationships']['section']['data']
+    assert_nil json_response['data']['relationships']['section']['data']
     assert_equal 'A great new Post', json_response['data']['attributes']['title']
     assert_equal 'AAAA', json_response['data']['attributes']['body']
     assert matches_array?([],
@@ -1116,7 +1116,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :no_content
     post_object = Post.find(4)
-    assert_equal nil, post_object.section_id
+    assert_nil post_object.section_id
   end
 
   def test_update_relationship_to_one_invalid_links_hash_keys_ids
@@ -1233,7 +1233,7 @@ class PostsControllerTest < ActionController::TestCase
     put :update_relationship, params: {post_id: 3, relationship: 'section', data: {type: 'sections', id: nil}}
 
     assert_response :no_content
-    assert_equal nil, post_object.reload.section_id
+    assert_nil post_object.reload.section_id
   end
 
   def test_update_relationship_to_one_data_nil
@@ -1246,7 +1246,7 @@ class PostsControllerTest < ActionController::TestCase
     put :update_relationship, params: {post_id: 3, relationship: 'section', data: nil}
 
     assert_response :no_content
-    assert_equal nil, post_object.reload.section_id
+    assert_nil post_object.reload.section_id
   end
 
   def test_remove_relationship_to_one
@@ -1260,7 +1260,7 @@ class PostsControllerTest < ActionController::TestCase
 
     assert_response :no_content
     post_object = Post.find(3)
-    assert_equal nil, post_object.section_id
+    assert_nil post_object.section_id
   end
 
   def test_update_relationship_to_one_singular_param
@@ -2546,7 +2546,7 @@ class Api::V5::AuthorsControllerTest < ActionController::TestCase
     assert_equal '1', json_response['data'][0]['id']
     assert_equal 'authors', json_response['data'][0]['type']
     assert_equal 'Joe Author', json_response['data'][0]['attributes']['name']
-    assert_equal nil, json_response['data'][0]['attributes']['email']
+    assert_nil json_response['data'][0]['attributes']['email']
   end
 
   def test_show_person_as_author
@@ -2555,7 +2555,7 @@ class Api::V5::AuthorsControllerTest < ActionController::TestCase
     assert_equal '1', json_response['data']['id']
     assert_equal 'authors', json_response['data']['type']
     assert_equal 'Joe Author', json_response['data']['attributes']['name']
-    assert_equal nil, json_response['data']['attributes']['email']
+    assert_nil json_response['data']['attributes']['email']
   end
 
   def test_get_person_as_author_by_name_filter

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -621,8 +621,8 @@ class Thing < ActiveRecord::Base
 end
 
 class RelatedThing < ActiveRecord::Base
-  belongs_to :from, class_name: Thing, foreign_key: :from_id
-  belongs_to :to, class_name: Thing, foreign_key: :to_id
+  belongs_to :from, class_name: 'Thing', foreign_key: :from_id
+  belongs_to :to, class_name: 'Thing', foreign_key: :to_id
 end
 
 class Question < ActiveRecord::Base

--- a/test/fixtures/book_comments.yml
+++ b/test/fixtures/book_comments.yml
@@ -4,7 +4,7 @@
 book_<%= book_num %>_comment_<%= comment_num %>:
   id: <%= comment_id %>
   body: This is comment <%= comment_num %> on book <%= book_num %>.
-  author_id: <%= book_num.even? ? comment_id % 2 : (comment_id % 2) + 2 %>
+  author_id: <%= (comment_id % 5) + 1 %>
   book_id: <%= book_num %>
   approved: <%= comment_num.even? %>
   <% comment_id = comment_id + 1 %>

--- a/test/helpers/query_counter.rb
+++ b/test/helpers/query_counter.rb
@@ -1,0 +1,17 @@
+class QueryCounter
+  attr_accessor :query_count
+
+  IGNORED_SQL = [/^PRAGMA (?!(table_info))/, /^SELECT currval/, /^SELECT CAST/, /^SELECT @@IDENTITY/, /^SELECT @@ROWCOUNT/, /^SAVEPOINT/, /^ROLLBACK TO SAVEPOINT/, /^RELEASE SAVEPOINT/, /^SHOW max_identifier_length/]
+
+  def initialize
+    self.query_count = 0
+  end
+
+  def call(name, start, finish, message_id, values)
+    # FIXME: this seems bad. we should probably have a better way to indicate
+    # the query was cached
+    unless 'CACHE' == values[:name]
+      self.query_count += 1 unless IGNORED_SQL.any? { |r| values[:sql] =~ r }
+    end
+  end
+end

--- a/test/integration/requests/request_test.rb
+++ b/test/integration/requests/request_test.rb
@@ -604,6 +604,36 @@ class RequestTest < ActionDispatch::IntegrationTest
   #   assert_equal 'This is comment 18 on book 1.', json_response['data'][9]['attributes']['body']
   # end
 
+  def test_query_count_related_resources
+    counter = QueryCounter.new
+    assert_equal 0, counter.query_count
+    ActiveSupport::Notifications.subscribe('sql.active_record', counter)
+    get '/api/v2/books/1/book_comments?page[limit]=20'
+    assert_equal 20, json_response['data'].size
+
+    # Expected Queries:
+    # * Fetch specified book record
+    # * Fetch book comment records associated with specified book
+    # * Select count of book comment records for pagination
+    assert_equal 3, counter.query_count
+  end
+
+  def test_query_count_related_resources_with_includes
+    counter = QueryCounter.new
+    assert_equal 0, counter.query_count
+    ActiveSupport::Notifications.subscribe('sql.active_record', counter)
+    get '/api/v2/books/1/book_comments?page[limit]=20&include=author'
+    assert_equal 20, json_response['data'].size
+    assert_equal 5, json_response['included'].size
+
+    # Expected Queries:
+    # * Fetch specified book record
+    # * Fetch book comment records associated with specified book
+    # * Fetch all author records the book comments to be returned
+    # * Select count of book comment records for pagination
+    assert_equal 4, counter.query_count
+  end
+
 
   def test_flow_self
     assert_cacheable_jsonapi_get '/posts'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,7 @@ require File.expand_path('../helpers/value_matchers', __FILE__)
 require File.expand_path('../helpers/assertions', __FILE__)
 require File.expand_path('../helpers/functional_helpers', __FILE__)
 require File.expand_path('../helpers/configuration_helpers', __FILE__)
+require File.expand_path('../helpers/query_counter', __FILE__)
 
 Rails.env = 'test'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ require 'rails/test_help'
 require 'minitest/mock'
 require 'jsonapi-resources'
 require 'pry'
+require 'bullet'
 
 require File.expand_path('../helpers/value_matchers', __FILE__)
 require File.expand_path('../helpers/assertions', __FILE__)
@@ -58,6 +59,11 @@ class TestApp < Rails::Application
     config.active_support.halt_callback_chains_on_return_false = false
     config.active_record.time_zone_aware_types = [:time, :datetime]
     config.active_record.belongs_to_required_by_default = false
+  end
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
   end
 end
 

--- a/test/unit/operation/operation_dispatcher_test.rb
+++ b/test/unit/operation/operation_dispatcher_test.rb
@@ -85,7 +85,7 @@ class OperationDispatcherTest < Minitest::Test
 
     op.process(operations)
     saturn.reload
-    assert_equal(saturn.planet_type_id, nil)
+    assert_nil(saturn.planet_type_id)
 
     # Reset
     operations = [

--- a/test/unit/serializer/link_builder_test.rb
+++ b/test/unit/serializer/link_builder_test.rb
@@ -39,10 +39,9 @@ class LinkBuilderTest < ActionDispatch::IntegrationTest
         primary_resource_klass: ApiV2Engine::PersonResource
     ).engine_name
 
-    assert_equal nil,
-      JSONAPI::LinkBuilder.new(
-        primary_resource_klass: Api::V1::PersonResource
-    ).engine_name
+    assert_nil JSONAPI::LinkBuilder.new(
+          primary_resource_klass: Api::V1::PersonResource
+      ).engine_name
   end
 
   def test_self_link_regular_app


### PR DESCRIPTION
Fixes #1163 

Updates related resources fetching logic to eagerly load any relationships to be included in the response. This prevents the relationships for each of these records from being fetched individually.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [x] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [x] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

Not sure if I'm intended to fill this section out but my recommendation would be to setup an API that has a variety of relationship chains and verify that fetching related resources with an included relationship does not result in N+1 queries being triggered. It would also be worthwhile to test for regressions in all other association related API requests.

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions