### PR TITLE
Allow included records to be filtered when also including nested reso…

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -257,7 +257,6 @@ module JSONAPI
         if included_resource_name
           relationship = resource_klass._relationship(included_resource_name || '')
 
-
           unless relationship
             return @errors.concat(Exceptions::FilterNotAllowed.new(filter_method).errors)
           end
@@ -266,7 +265,10 @@ module JSONAPI
             return @errors.concat(Exceptions::FilterNotAllowed.new(filter_method).errors)
           end
 
-          unless @include_directives.model_includes.include?(relationship.name.to_sym)
+          # Supports only just-included or top-level of multiple-relationship includes, e.g.,
+          # ?include=parent,parent.child&filter[parent.arms]=3
+          filtered_relationship_included = @include_directives.model_includes.include?(relationship.name.to_sym) || @include_directives.model_includes.any? { |include| include.key?(relationship.name.to_sym) }
+          unless filtered_relationship_included
             return @errors.concat(Exceptions::FilterNotAllowed.new(filter_method).errors)
           end
 

--- a/test/controllers/controller_test.rb
+++ b/test/controllers/controller_test.rb
@@ -2601,6 +2601,16 @@ class Api::V5::PaintersControllerTest < ActionController::TestCase
     assert_equal '4', json_response['included'][0]['id']
   end
 
+  def test_index_with_filters_and_included_resources_with_filters_and_nested_include
+    get :index, params: { include: 'paintings,paintings.collectors', filter: { 'name' => 'Wyspianski', 'paintings.category' => 'oil' } }
+
+    assert_response :success
+    assert_equal 1, json_response['data'].size
+    assert_equal '1', json_response['data'][0]['id']
+    assert_equal 4, json_response['included'].size
+    assert_equal '4', json_response['included'][0]['id']
+  end
+
   def test_index_with_filters_and_included_resources_with_multiple_filters
     # Painting 5 is the genuine, but painting 6 is a fake. Verify that multiple nested filters are merged and only the oil painting is returned.
     get :index, params: { include: 'paintings', filter: { 'name' => 'Wyspianski', 'paintings.category' => 'oil', 'paintings.title' => 'Motherhood' } }

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1674,7 +1674,7 @@ module Api
       has_many :paintings
 
       filter :name, apply: lambda { |records, value, options|
-        records.where('name LIKE ?', value)
+        records.where("#{_model_class.table_name}.name LIKE ?", value)
       }
 
       def records_for(relation_name)


### PR DESCRIPTION
…urces



### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [ ] I've included an explanation of what the changes do and why I'd like you to include them.
- [ ] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [x] Maintains compliance with JSON:API
- [x] Adequate test coverage exists to prevent regressions