### PR TITLE
Allow included resources to be filtered when they are related with th…

### DIFF
--- a/lib/jsonapi/request_parser.rb
+++ b/lib/jsonapi/request_parser.rb
@@ -265,10 +265,7 @@ module JSONAPI
             return @errors.concat(Exceptions::FilterNotAllowed.new(filter_method).errors)
           end
 
-          # Supports only just-included or top-level of multiple-relationship includes, e.g.,
-          # ?include=parent,parent.child&filter[parent.arms]=3
-          filtered_relationship_included = @include_directives.model_includes.include?(relationship.name.to_sym) || @include_directives.model_includes.any? { |include| include.key?(relationship.name.to_sym) }
-          unless filtered_relationship_included
+          unless @include_directives.include_config(relationship.name.to_sym).present?
             return @errors.concat(Exceptions::FilterNotAllowed.new(filter_method).errors)
           end
 

--- a/lib/jsonapi/resource.rb
+++ b/lib/jsonapi/resource.rb
@@ -741,6 +741,9 @@ module JSONAPI
           next memo unless relationship && relationship.is_a?(JSONAPI::Relationship::ToMany)
           filtering_resource = relationship.resource_klass
 
+          # Don't try to merge where clauses when relation isn't already being joined to query.
+          next memo unless config[:include_in_join]
+
           filters = config[:include_filters]
           next memo unless filters
 

--- a/test/fixtures/active_record.rb
+++ b/test/fixtures/active_record.rb
@@ -1056,6 +1056,7 @@ class TagResource < JSONAPI::Resource
   attributes :name
 
   has_many :posts
+  filter :name
   # Not including the planets relationship so they don't get output
   #has_many :planets
 end


### PR DESCRIPTION
…e 'eager_load_on_include: false' flag set

Filtering of included resources currently breaks if those included resources are not eagerly-loaded on the relation with the primary object.  This happens because we attempt to shove all of the `included_filters` on the primary `where` clause for retrieving the object.  We also validate filters based on `model_includes`, which breaks when the related resources are not eagerly-loaded.

Instead, we'll let the `records_for_<blah>` continue passing included filters as part of its `options`, validate filters based on the `include_config` helper, and only include additional filters in the primary where when those relations are in fact eagerly loaded.

### All Submissions:

- [x] I've checked to ensure there aren't other open [Pull Requests](https://github.com/cerebris/jsonapi-resources/pulls) for the same update/change.
- [ ] I've submitted a [ticket](https://github.com/cerebris/jsonapi-resources/issues) for my issue if one did not already exist.
- [x] My submission passes all tests. (Please run the full test suite locally to cut down on noise from travis failures.)
- [ ] I've used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message or the description.
- [x] I've added/updated tests for this change.

### New Feature Submissions:

- [ ] I've submitted an issue that describes this feature, and received the go ahead from the maintainers.
- [ ] My submission includes new tests.
- [ ] My submission maintains compliance with [JSON:API](http://jsonapi.org/).

### Bug fixes and Changes to Core Features:

- [x] I've included an explanation of what the changes do and why I'd like you to include them.
- [x] I've provided test(s) that fails without the change.

### Test Plan:

### Reviewer Checklist:
- [ ] Maintains compliance with JSON:API
- [ ] Adequate test coverage exists to prevent regressions